### PR TITLE
fix: upgrade axios to 1.12.0, 0.30.2 (CVE-2025-58754)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.0",
       "dependencies": {
         "async": "^3.2.6",
-        "axios": "^1.11.0",
+        "axios": "^1.12.0",
         "colors": "^1.4.0",
         "command-exists": "^1.2.9",
         "commander": "^14.0.0",
@@ -40,9 +40,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
+      "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -8,16 +8,16 @@
   },
   "dependencies": {
     "async": "^3.2.6",
-    "axios": "^1.11.0",
+    "axios": "^1.12.0",
     "colors": "^1.4.0",
     "command-exists": "^1.2.9",
     "commander": "^14.0.0",
     "dateformat": "^5.0.3",
     "get-stdin": "^9.0.0",
     "is-valid-path": "^0.1.1",
-    "validator": "^13.15.15",
     "progress": "^2.0.3",
-    "valid-url": "^1.0.9"
+    "valid-url": "^1.0.9",
+    "validator": "^13.15.15"
   },
   "devDependencies": {
     "prettier": "^3.6.2"


### PR DESCRIPTION
## Summary
Upgrade axios from 1.11.0 to 1.12.0, 0.30.2 to fix CVE-2025-58754.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2025-58754 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2025-58754` |
| **File** | `package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: axios: Axios DoS via lack of data size check

## Evidence

**Scanner confirmation**: trivy rule `CVE-2025-58754` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `package.json`
- `package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
